### PR TITLE
we need 'name' for Context

### DIFF
--- a/discordapi/slash/command.py
+++ b/discordapi/slash/command.py
@@ -51,6 +51,7 @@ __all__ = [
 
 CTX_KEYLIST = [
     "id",
+    "name",
     "application_id",
     "type",
     "data",


### PR DESCRIPTION
```
[ERROR]|2022-01-30 21:03:07,270|main|_event_loop|: Exception occured while running dispatcher function.
Traceback (most recent call last):
  File "C:\Users\{USER_NAME}\PycharmProjects\time-bot\NicoBot\discordapi\websocket.py", line 200, in _event_loop
    self.dispatcher(parsed_data)
  File "C:\Users\{USER_NAME}\PycharmProjects\time-bot\NicoBot\discordapi\gateway.py", line 224, in _dispatcher
    self.handler.handle(event, obj)
  File "C:\Users\{USER_NAME}\PycharmProjects\time-bot\NicoBot\discordapi\handler.py", line 149, in handle
    handler(obj)
  File "C:\Users\{USER_NAME}\PycharmProjects\time-bot\NicoBot\discordapi\slash\client.py", line 189, in on_interaction_create
    self.client.command_manager.execute(obj)
  File "C:\Users\{USER_NAME}\PycharmProjects\time-bot\NicoBot\discordapi\slash\command.py", line 317, in execute
    for res in gen:
  File "C:\Users\{USER_NAME}\PycharmProjects\time-bot\NicoBot\discordapi\slash\command.py", line 229, in execute
    gen = self.func(ctx=ctx, **kwargs)
  File "C:\Users\{USER_NAME}\PycharmProjects\time-bot\bot.py", line 53, in ct
    print(ctx, tz_name)
  File "C:\Users\{USER_NAME}\PycharmProjects\time-bot\NicoBot\discordapi\dictobject.py", line 58, in __str__
    return self._get_str(class_name, self.id, self.name)
AttributeError: 'Context' object has no attribute 'name'
```